### PR TITLE
Disable levenshtein distance, and default to normal forms

### DIFF
--- a/commands/pokemon.js
+++ b/commands/pokemon.js
@@ -11,6 +11,8 @@ const {
   gameVersion,
 } = require('../helpers.js');
 
+const fuzzyPokemon = FuzzySet(pokemonList.map(p => p.name.toLowerCase()), false);
+
 module.exports = {
   name        : 'pokemon',
   aliases     : ['p', 'poke', 'pinfo', 'pokeinfo'],
@@ -30,11 +32,17 @@ module.exports = {
 
     let pokemon = pokemonList.find(p => p.id == +id || p.name.toLowerCase() == id);
     if (!pokemon && isNaN(id)) {
-      const fuzzy = FuzzySet(pokemonList.map(p => p.name.toLowerCase()));
-
-      const newNames = fuzzy.get(id);
+      const newNames = fuzzyPokemon.get(id);
       if (newNames) {
         pokemon = pokemonList.find(p => p.name.toLowerCase() == newNames[0][1]);
+
+        // If this pokemon is an alternate form,
+        // but the user input didn't include a space,
+        // they probably just want the basic form
+        if (!Number.isInteger(pokemon.id) && !id.includes(' ')) {
+          const firstFormID = Math.floor(pokemon.id);
+          pokemon = pokemonList.find(p => p.id == firstFormID) || pokemon;
+        }
       }
     }
     if (!pokemon) pokemon = pokemonList.find(p => p.id == 0);


### PR DESCRIPTION
Passing false as the second argument to the FuzzySet constructor disables using Levenshtein distance, which gives us better matches for shortened names at the cost of potentially worse matches for misspellings.

With this change, we get better matches for the pokemon with alternate forms, without having to specify the form you want to see
"arc" -> Arceus (Normal)
"arc ice" -> Arceus (Ice)

An example of a bad match on a misspelling:
"pokochu" -> Pichu


It seems that people are mostly using this command with a partial name for pokemon though, so I think this is an improvement overall