### PR TITLE
Feature/restrict commands to channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Pokéclicker Discord Bot
+
+This is the code for the Pokéclicker Discord Bot. In order to run it locally for development, you must set up a [Discord Application](https://discord.com/developers/applications) with a bot token, and invite it to a server that you can manage.
+
+Steps for running:
+
+* Copy `_config.json` to `config.json` and change the settings
+* Run `npm ci` to install dependencies
+* Run `npm start` to start the server
+* Open the invite link provided in the console, and add the bot to a server, then grant it a role with the permissions listed below
+
+## Permissions
+
+* `ATTACH_FILES` - Attach Files - Used for `!backup`
+* `DELETE_MESSAGE` - Manage Messages - Used for `!post`
+* `SEND_MESSAGES` - Used for all
+* `EMBED_LINKS` - Used for all

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Steps for running:
 
 ## Permissions
 
-* `ATTACH_FILES` - Attach Files - Used for `!backup`
-* `DELETE_MESSAGE` - Manage Messages - Used for `!post`
-* `SEND_MESSAGES` - Used for all
-* `EMBED_LINKS` - Used for all
+* Manage Roles - Allow the bot to assign and unassign roles with `!mute`, `!unmute`, and `!scripting`
+* Read Text Channels & See Voice Channels
+* Send Messages
+* Manage Messages - Allow the bot to delete messages
+* Embedded Links
+* Attach files - Allow the bot to post database backups
+* Mention `@everyone`, `@here` and All Roles

--- a/_config.json
+++ b/_config.json
@@ -2,8 +2,8 @@
   "prefix": "!",
   "token": "YOUR_BOTS_TOKEN_HERE",
   "website": "https://LINK.TO.WEBSITE/",
-  "owner_ID": "YOUR_DISCORD_USER_ID (optional)",
-  "backup_channel_ID": "DISCORD_BACKUP_CHANNEL_ID (optional)",
+  "ownerID": "YOUR_DISCORD_USER_ID (optional)",
+  "backupChannelID": "DISCORD_BACKUP_CHANNEL_ID (optional)",
   "mutedRoleID": "758167963294629898",
   "externalScriptsRoleID": "761015248856809493"
 }

--- a/_config.json
+++ b/_config.json
@@ -3,5 +3,7 @@
   "token": "YOUR_BOTS_TOKEN_HERE",
   "website": "https://LINK.TO.WEBSITE/",
   "owner_ID": "YOUR_DISCORD_USER_ID (optional)",
-  "backup_channel_ID": "DISCORD_BACKUP_CHANNEL_ID (optional)"
+  "backup_channel_ID": "DISCORD_BACKUP_CHANNEL_ID (optional)",
+  "mutedRoleID": "758167963294629898",
+  "externalScriptsRoleID": "761015248856809493"
 }

--- a/commands/backup.js
+++ b/commands/backup.js
@@ -9,7 +9,7 @@ module.exports = {
   cooldown    : 0.1,
   botperms    : ['ATTACH_FILES'],
   userperms   : ['MANAGE_GUILD'],
-  channels    : [], // Restricted channel
+  channels    : [], // default restricted channels
   execute     : async (msg, args) => {
     backupDB(msg.guild);
   },

--- a/commands/backup.js
+++ b/commands/backup.js
@@ -9,6 +9,7 @@ module.exports = {
   cooldown    : 0.1,
   botperms    : ['ATTACH_FILES'],
   userperms   : ['MANAGE_GUILD'],
+  channels    : [], // Restricted channel
   execute     : async (msg, args) => {
     backupDB(msg.guild);
   },

--- a/commands/balance.js
+++ b/commands/balance.js
@@ -10,7 +10,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['bot-commands', 'bragging', 'game-corner'],
+  channels    : ['bot-commands', 'game-corner', 'bragging'],
   execute     : async (msg, args) => {
     const balance = await getAmount(msg.author);
 

--- a/commands/balance.js
+++ b/commands/balance.js
@@ -10,6 +10,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands', 'bragging', 'game-corner'],
   execute     : async (msg, args) => {
     const balance = await getAmount(msg.author);
 

--- a/commands/claim.js
+++ b/commands/claim.js
@@ -29,6 +29,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (msg, args) => {
     // Check if user claimed within the last 24 hours
     let { last_claim, streak } = await getLastClaim(msg.author, 'daily_claim');

--- a/commands/dailychain.js
+++ b/commands/dailychain.js
@@ -15,6 +15,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     let [maxSlots, fromDate, days] = args;
 

--- a/commands/dailydeal.js
+++ b/commands/dailydeal.js
@@ -15,6 +15,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     let [date] = args;
     if (date) {

--- a/commands/eval.js
+++ b/commands/eval.js
@@ -1,5 +1,5 @@
 const { error } = require('../helpers.js');
-const config = require('../config.json');
+const { ownerID } = require('../config.json');
 const clean = text => {
   if (typeof(text) === 'string')
     return text.replace(/`/g, `\`${String.fromCharCode(8203)}`).replace(/@/g, `@${String.fromCharCode(8203)}`);
@@ -18,7 +18,7 @@ module.exports = {
   userperms   : ['MANAGE_GUILD'],
   channels    : [], // `dev-bot` is automatically allowed
   execute     : async (msg, args) => {
-    if(!config.owner_ID || msg.author.id !== config.owner_ID) return;
+    if (!ownerID || msg.author.id !== ownerID) return;
     try {
       let script = (msg.content.match(/```js\r?\n(.+|\r?\n)+\r?\n```$/) || [''])[0];
       script = script ? script.substr(6, script.length - 10) : args.join(' ');

--- a/commands/eval.js
+++ b/commands/eval.js
@@ -16,6 +16,7 @@ module.exports = {
   cooldown    : 0.1,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['MANAGE_GUILD'],
+  channels    : [], // `dev-bot` is automatically allowed
   execute     : async (msg, args) => {
     if(!config.owner_ID || msg.author.id !== config.owner_ID) return;
     try {

--- a/commands/eval.js
+++ b/commands/eval.js
@@ -16,7 +16,7 @@ module.exports = {
   cooldown    : 0.1,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['MANAGE_GUILD'],
-  channels    : [], // `dev-bot` is automatically allowed
+  channels    : [], // default restricted channels
   execute     : async (msg, args) => {
     if (!ownerID || msg.author.id !== ownerID) return;
     try {

--- a/commands/flip.js
+++ b/commands/flip.js
@@ -35,6 +35,7 @@ module.exports = {
   cooldown    : 0.5,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['game-corner', 'bot-commands'],
   execute     : async (msg, args) => {
     let bet = args.find(a => betRegex.test(a));
     let side = args.find(a => new RegExp(`^(${Object.keys(coinSides).join('|')})$`, 'i').test(a));

--- a/commands/flip.js
+++ b/commands/flip.js
@@ -35,7 +35,7 @@ module.exports = {
   cooldown    : 0.5,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['game-corner', 'bot-commands'],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (msg, args) => {
     let bet = args.find(a => betRegex.test(a));
     let side = args.find(a => new RegExp(`^(${Object.keys(coinSides).join('|')})$`, 'i').test(a));

--- a/commands/gift.js
+++ b/commands/gift.js
@@ -10,6 +10,7 @@ module.exports = {
   cooldown    : 1,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['MANAGE_GUILD'],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (msg, args) => {
     const amount = +(args.find(arg=>/^-?\d+$/.test(arg)) || 10);
     

--- a/commands/gift.js
+++ b/commands/gift.js
@@ -10,7 +10,7 @@ module.exports = {
   cooldown    : 1,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['MANAGE_GUILD'],
-  channels    : ['bot-commands', 'game-corner'],
+  channels    : [], // default restricted channels
   execute     : async (msg, args) => {
     const amount = +(args.find(arg=>/^-?\d+$/.test(arg)) || 10);
     

--- a/commands/help.js
+++ b/commands/help.js
@@ -20,7 +20,7 @@ module.exports = {
     if (msg.channel.type === 'dm'){
       commands = commands.filter(command => !command.guildOnly);
     } else if (msg.channel.type === 'text'){
-      commands = commands.filter(command => !msg.channel.memberPermissions(msg.member).missing(command.userperms).length);
+      commands = commands.filter(command => !msg.channel.permissionsFor(msg.member).missing(command.userperms).length);
     }
 
     if (!args.length) {

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,5 +1,9 @@
-const { MessageEmbed } = require('discord.js');
-const { upperCaseFirstLetter } = require('../helpers.js');
+const { Collection, MessageEmbed } = require('discord.js');
+const {
+  upperCaseFirstLetter,
+  getAvailableChannelList,
+  formatChannelList,
+} = require('../helpers.js');
 const { prefix } = require('../config.json');
 
 module.exports = {
@@ -30,7 +34,33 @@ module.exports = {
         ])
         .setColor('#3498db');
 
-      commands.forEach(command => embed.addField(`❯ ${upperCaseFirstLetter(command.name)}`, [`${command.description.split('\n')[0]}`], true));
+      commands
+        // Group the commands by their primary channel
+        .reduce((acc, next) => {
+          const allowedChannels = getAvailableChannelList(msg.guild, next.channels);
+          let currChannel = 'Any';
+          // If this command is restricted to a channel, use the first channel
+          if (allowedChannels !== true) {
+            currChannel = allowedChannels.size === 0
+              ? 'Restricted'
+              : allowedChannels.first().name;
+          }
+
+          if (!acc.has(currChannel)) acc.set(currChannel, []);
+          acc.get(currChannel).push(next);
+          return acc;
+        }, new Collection())
+        .forEach((channelCommands, rawChannelName) => {
+          const channel = msg.guild.channels.cache.find((v) => v.name === rawChannelName) || rawChannelName;
+          const channelDescription = channelCommands.reduce((acc, command) => acc.concat(
+            `❯ **${upperCaseFirstLetter(command.name)}**: ${command.description.split('\n')[0]}`
+          ), []);
+          embed.addField(
+            channel.name ? `#${channel.name}` : `${channel} channel`,
+            channelDescription,
+            false
+          );
+        });
       return msg.channel.send({ embed });
     }
 
@@ -48,7 +78,8 @@ module.exports = {
       .addField('❯ Usage', `\`\`\`css\n${prefix}${command.name}${command.args.map(arg=>` [${arg}]`).join('')}\`\`\``)
       .addField('❯ Aliases', `\`${command.aliases.join('`, `') || '-'}\``, true)
       .addField('❯ Cooldown', `\`${command.cooldown || 3} second(s)\``, true)
-      .addField('❯ Guild Only', `\`${command.guildOnly}\``, true);
+      .addField('❯ Guild Only', `\`${command.guildOnly}\``, true)
+      .addField('❯ Channels', formatChannelList(msg.guild, command.channels), true);
 
     if (command.helpFields) {
       embed.addField('\u200b\n═══ More Information ═══', '\u200b');

--- a/commands/mute.js
+++ b/commands/mute.js
@@ -1,6 +1,5 @@
 const { MessageEmbed } = require('discord.js');
-
-const mutedRoleID = '758167963294629898';
+const { mutedRoleID } = require('../config.json');
 
 module.exports = {
   name        : 'mute',

--- a/commands/mute.js
+++ b/commands/mute.js
@@ -10,7 +10,7 @@ module.exports = {
   guildOnly   : true,
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
-  userperms   : ['MUTE_MEMBERS'], // Voice mut permission
+  userperms   : ['MUTE_MEMBERS'], // Voice mute permission
   execute     : async (msg, args) => {
     const embed = new MessageEmbed().setColor('#e74c3c');
 

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -3,7 +3,7 @@ const { MessageEmbed } = require('discord.js');
 module.exports = {
   name        : 'ping',
   aliases     : [],
-  description : 'Check that i\'m still responding',
+  description : 'Check that I\'m still responding',
   args        : [],
   guildOnly   : false,
   cooldown    : 3,

--- a/commands/pokemon.js
+++ b/commands/pokemon.js
@@ -23,6 +23,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     let id = args.join(' ').toLowerCase().trim();
     let shiny = false;

--- a/commands/post.js
+++ b/commands/post.js
@@ -18,7 +18,7 @@ module.exports = {
       return msg.reply('You didn\'t specify a channel..');
     }
     const channel = msg.mentions.channels.first();
-    if (channel.memberPermissions(msg.guild.me).missing(['VIEW_CHANNEL', 'SEND_MESSAGES']).length){
+    if (channel.permissionsFor(msg.guild.me).missing(['VIEW_CHANNEL', 'SEND_MESSAGES']).length){
       return msg.reply(`I don't have permission to post in ${channel}..`);
     }
 

--- a/commands/post.js
+++ b/commands/post.js
@@ -9,7 +9,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['MANAGE_GUILD'],
-  channels    : [], // `dev-bot` is automatically allowed
+  channels    : [], // default restricted channels
   execute     : async (msg, args) => {
     msg.delete().catch(e=>error('Unable to delete message:', e));
     const [, message_id] = args;

--- a/commands/post.js
+++ b/commands/post.js
@@ -9,6 +9,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['MANAGE_GUILD'],
+  channels    : [], // `dev-bot` is automatically allowed
   execute     : async (msg, args) => {
     msg.delete().catch(e=>error('Unable to delete message:', e));
     const [, message_id] = args;

--- a/commands/profile.js
+++ b/commands/profile.js
@@ -17,6 +17,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands', 'bragging', 'game-corner'],
   execute     : async (msg, args) => {
     const balance = await getAmount(msg.author);
     const rank = await getRank(msg.author);

--- a/commands/profile.js
+++ b/commands/profile.js
@@ -17,7 +17,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['bot-commands', 'bragging', 'game-corner'],
+  channels    : ['bot-commands', 'game-corner', 'bragging'],
   execute     : async (msg, args) => {
     const balance = await getAmount(msg.author);
     const rank = await getRank(msg.author);

--- a/commands/profileshop.js
+++ b/commands/profileshop.js
@@ -12,7 +12,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['bot-commands'],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (msg, args) => {
     let [ page = 1 ] = args;
 

--- a/commands/profileshop.js
+++ b/commands/profileshop.js
@@ -12,6 +12,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     let [ page = 1 ] = args;
 

--- a/commands/ranked.js
+++ b/commands/ranked.js
@@ -14,6 +14,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands', 'bragging', 'game-corner'],
   execute     : async (msg, args) => {
     const embed = new MessageEmbed()
       .setTitle('Top ranked Pokémon')

--- a/commands/ranked.js
+++ b/commands/ranked.js
@@ -7,14 +7,14 @@ const {
 
 module.exports = {
   name        : 'ranked',
-  aliases     : ['ranks', 'rank', 'r'],
+  aliases     : ['ranks', 'rank'],
   description : 'Get a list of the top ranked Pokémon',
   args        : [],
   guildOnly   : true,
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['bot-commands', 'bragging', 'game-corner'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     const embed = new MessageEmbed()
       .setTitle('Top ranked Pokémon')

--- a/commands/route.js
+++ b/commands/route.js
@@ -12,7 +12,7 @@ const { website } = require('../config.json');
 
 module.exports = {
   name        : 'route',
-  aliases     : ['routes', 'routeinfo'],
+  aliases     : ['routes', 'routeinfo', 'r'],
   description : 'Get PokéClicker game info about a specific route',
   args        : ['id', 'region?'],
   guildOnly   : true,

--- a/commands/route.js
+++ b/commands/route.js
@@ -13,12 +13,13 @@ const { website } = require('../config.json');
 module.exports = {
   name        : 'route',
   aliases     : ['routes', 'routeinfo'],
-  description : 'Get PokéClicker game info about a specific Pokémon',
+  description : 'Get PokéClicker game info about a specific route',
   args        : ['id', 'region?'],
   guildOnly   : true,
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     const [routeNumber, region] = args;
     if (isNaN(routeNumber)) return msg.reply(`Invalid route number: \`${routeNumber}\``);

--- a/commands/scripting.js
+++ b/commands/scripting.js
@@ -10,7 +10,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS', 'MANAGE_ROLES'],
   userperms   : ['MUTE_MEMBERS'], // Voice mute permission
-  channels    : ['mod-bot'],
+  channels    : [], // default restricted channels
   execute     : async (msg, args) => {
     const embed = new MessageEmbed().setColor('#e74c3c');
 

--- a/commands/scripting.js
+++ b/commands/scripting.js
@@ -1,6 +1,5 @@
 const { MessageEmbed } = require('discord.js');
-
-const externalScriptsRoleID = '761015248856809493';
+const { externalScriptsRoleID } = require('../config.json');
 
 module.exports = {
   name        : 'scripting',

--- a/commands/scripting.js
+++ b/commands/scripting.js
@@ -10,7 +10,8 @@ module.exports = {
   guildOnly   : true,
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS', 'MANAGE_ROLES'],
-  userperms   : ['MUTE_MEMBERS'], // Voice mut permission
+  userperms   : ['MUTE_MEMBERS'], // Voice mute permission
+  channels    : ['mod-bot'],
   execute     : async (msg, args) => {
     const embed = new MessageEmbed().setColor('#e74c3c');
 

--- a/commands/shards.js
+++ b/commands/shards.js
@@ -19,6 +19,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     let [type, order] = args;
     type = type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();

--- a/commands/shop.js
+++ b/commands/shop.js
@@ -53,6 +53,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     let [ page = 1 ] = args;
 

--- a/commands/slots.js
+++ b/commands/slots.js
@@ -168,7 +168,7 @@ module.exports = {
   cooldown    : 0.5,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['game-corner', 'bot-commands'],
+  channels    : ['bot-commands', 'game-corner'],
   execute      : async (msg, args) => {
     let [ bet, lines = 3 ] = args;
 

--- a/commands/slots.js
+++ b/commands/slots.js
@@ -168,6 +168,7 @@ module.exports = {
   cooldown    : 0.5,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['game-corner', 'bot-commands'],
   execute      : async (msg, args) => {
     let [ bet, lines = 3 ] = args;
 

--- a/commands/spin.js
+++ b/commands/spin.js
@@ -17,7 +17,7 @@ module.exports = {
   cooldown    : 0.5,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['game-corner', 'bot-commands'],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (msg, args) => {
     let bet = args.find(a => betRegex.test(a));
 

--- a/commands/spin.js
+++ b/commands/spin.js
@@ -17,6 +17,7 @@ module.exports = {
   cooldown    : 0.5,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['game-corner', 'bot-commands'],
   execute     : async (msg, args) => {
     let bet = args.find(a => betRegex.test(a));
 

--- a/commands/template
+++ b/commands/template
@@ -7,6 +7,11 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['MANAGE_CHANNELS', 'MANAGE_MESSAGES'],
+  // If you provide `channels`, it will limit the command's usage to those
+  // channels (as well as `#dev-bot` automatically). To allow in all channels,
+  // remove the option entirely, and to restrict usage to only users with the
+  // `MANAGE_GUILD` permission, set it to `[]`
+  channels    : ['bot-commands'],
   execute     : async (msg, args) => {
     return
   },

--- a/commands/timely.js
+++ b/commands/timely.js
@@ -24,6 +24,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (msg, args) => {
     // Check if user claimed within the last 24 hours
     let { last_claim, streak } = await getLastClaim(msg.author, 'timely_claim');

--- a/commands/top.js
+++ b/commands/top.js
@@ -10,7 +10,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['SEND_MESSAGES'],
-  channels    : ['bot-commands', 'bragging', 'game-corner'],
+  channels    : ['bot-commands', 'game-corner', 'bragging'],
   execute     : async (msg, args) => {
     const results = await getTop(100);
     const resultsText = results.map((res, place) => `**#${place + 1}** \`${res.amount ? res.amount.toLocaleString('en-NZ') : 0}\` <:money:737206931759824918> <@!${res.user}>`);

--- a/commands/top.js
+++ b/commands/top.js
@@ -10,6 +10,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES'],
   userperms   : ['SEND_MESSAGES'],
+  channels    : ['bot-commands', 'bragging', 'game-corner'],
   execute     : async (msg, args) => {
     const results = await getTop(100);
     const resultsText = results.map((res, place) => `**#${place + 1}** \`${res.amount ? res.amount.toLocaleString('en-NZ') : 0}\` <:money:737206931759824918> <@!${res.user}>`);

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -1,6 +1,5 @@
 const { MessageEmbed } = require('discord.js');
-
-const mutedRoleID = '758167963294629898';
+const { mutedRoleID } = require('../config.json');
 
 module.exports = {
   name        : 'unmute',

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -11,7 +11,6 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS', 'MANAGE_ROLES'],
   userperms   : ['MUTE_MEMBERS'], // Voice mute permission
-  channels    : ['mod-bot'],
   execute     : async (msg, args) => {
     const embed = new MessageEmbed().setColor('#e74c3c');
 

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -10,7 +10,8 @@ module.exports = {
   guildOnly   : true,
   cooldown    : 3,
   botperms    : ['SEND_MESSAGES', 'EMBED_LINKS', 'MANAGE_ROLES'],
-  userperms   : ['MUTE_MEMBERS'], // Voice mut permission
+  userperms   : ['MUTE_MEMBERS'], // Voice mute permission
+  channels    : ['mod-bot'],
   execute     : async (msg, args) => {
     const embed = new MessageEmbed().setColor('#e74c3c');
 

--- a/database.js
+++ b/database.js
@@ -1,5 +1,5 @@
 const sqlite = require('sqlite');
-const { backup_channel_ID } = require('./config.json');
+const { backupChannelID } = require('./config.json');
 const { MessageAttachment } = require('discord.js');
 
 const database_dir = './db/';
@@ -26,7 +26,7 @@ async function setupDB(){
 
 async function backupDB(guild){
   // Check if this guild has a backup channel
-  const backup_channel = await guild.channels.cache.get(backup_channel_ID);
+  const backup_channel = await guild.channels.cache.get(backupChannelID);
   if (!backup_channel) return;
 
   const attachment = await new MessageAttachment().setFile(database_fullpath, 'database.backup.sqlite');

--- a/helpers/formatChannelList.js
+++ b/helpers/formatChannelList.js
@@ -1,0 +1,26 @@
+// Convert a list of channels into channels available in this guild
+// ['bot-commands'] -> '#bot-commands'
+// ['bot-commands', 'game-corner'] -> '#bot-commands or #game corner'
+// ['bot-commands', 'game-corner', 'bragging'] -> '#bot-commands, #game-corner, or #bragging'
+const formatChannelList = (guild, channels) => guild.channels.cache
+  // Find all allowed channels
+  .filter((channel) => channels.includes(channel.name))
+  // Sort by priority
+  .sorted((a, b) => channels.indexOf(a.name) - channels.indexOf(b.name))
+  // Turn the sorted list into a human-readable string
+  .reduce((acc, next, key, arr) => {
+    let joiner = '';
+    // If we're not looking at the first item, set the joiner
+    if (acc) {
+      joiner = ', ';
+      // If we're looking at the last item, determine if we should use a comma
+      if (key === arr.lastKey()) {
+        joiner = arr.size === 2 ? ' or ' : ', or ';
+      }
+    }
+    return `${acc}${joiner}${next}`;
+  }, '');
+
+module.exports = {
+  formatChannelList,
+};

--- a/helpers/formatChannelList.js
+++ b/helpers/formatChannelList.js
@@ -1,14 +1,28 @@
+const { Collection } = require('discord.js');
+
+const getAvailableChannelList = (guild, channels = true) => {
+  // All channels are allowed
+  if (channels === true) return true;
+  // Restricted commands
+  if (channels.length === 0) return new Collection();
+  // Find the available channels
+  return guild.channels.cache
+    // Find all allowed channels
+    .filter((channel) => channels.includes(channel.name))
+    // Sort by priority
+    .sorted((a, b) => channels.indexOf(a.name) - channels.indexOf(b.name));
+};
+
 // Convert a list of channels into channels available in this guild
 // ['bot-commands'] -> '#bot-commands'
 // ['bot-commands', 'game-corner'] -> '#bot-commands or #game corner'
 // ['bot-commands', 'game-corner', 'bragging'] -> '#bot-commands, #game-corner, or #bragging'
-const formatChannelList = (guild, channels) => guild.channels.cache
-  // Find all allowed channels
-  .filter((channel) => channels.includes(channel.name))
-  // Sort by priority
-  .sorted((a, b) => channels.indexOf(a.name) - channels.indexOf(b.name))
-  // Turn the sorted list into a human-readable string
-  .reduce((acc, next, key, arr) => {
+const formatChannelList = (guild, channels) => {
+  const availableChannels = getAvailableChannelList(guild, channels);
+  if (availableChannels === true) return 'any channel';
+
+  // Turn the list into a human-readable string
+  return availableChannels.reduce((acc, next, key, arr) => {
     let joiner = '';
     // If we're not looking at the first item, set the joiner
     if (acc) {
@@ -20,7 +34,9 @@ const formatChannelList = (guild, channels) => guild.channels.cache
     }
     return `${acc}${joiner}${next}`;
   }, '');
+};
 
 module.exports = {
+  getAvailableChannelList,
   formatChannelList,
 };

--- a/index.js
+++ b/index.js
@@ -96,12 +96,12 @@ client.on('error', e => error('Client error thrown:', e))
     );
 
     if (!commandAllowedHere) {
-      let botReply = [`This is not the correct channel for \`${prefix}${command.name}\`.`];
+      const output = [`This is not the correct channel for \`${prefix}${command.name}\`.`];
       if (command.channels && command.channels.length !== 0) {
-        botReply.push(`Please try again in ${formatChannelList(message.guild, command.channels)}.`);
+        output.push(`Please try again in ${formatChannelList(message.guild, command.channels)}.`);
       }
       message.delete().catch((e) => error('Unable to delete message:', e));
-      return message.reply(botReply);
+      return message.reply(output);
     }
 
     // Check the user has supplied enough arguments for the command

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {
   error,
   gameVersion,
   RunOnInterval,
+  formatChannelList,
 } = require('./helpers.js');
 const {
   setupDB,
@@ -91,15 +92,14 @@ client.on('error', e => error('Client error thrown:', e))
     );
 
     if (!commandAllowedHere) {
-      const botChannels = command.channels && message.guild.channels.cache
-        // Find all allowed channels
-        .filter((channel) => command.channels.includes(channel.name))
-        // Sort by priority
-        .sort((a, b) => command.channels.indexOf(a.name) - command.channels.indexOf(b.name));
-      const botChannel = botChannels && botChannels.length !== 0
-        ? ` Please try again in ${botChannels.first()}`
-        : '';
-      return message.reply(`You're not allowed to use that here.${botChannel}`);
+      let botChannelMessage = '';
+      if (command.channels && command.channels.length !== 0) {
+        botChannelMessage = `Please try again in ${formatChannelList(message.guild, command.channels)}.`
+      }
+      const safeMessage = message.content.replace(/`/g, '');
+      return message
+        .reply(`This is not the correct channel for \`${safeMessage}\`. ${botChannelMessage}`)
+        .then(() => message.delete().catch((e) => error('Unable to delete message:', e)));
     }
 
     // Check the user has supplied enough arguments for the command

--- a/index.js
+++ b/index.js
@@ -88,8 +88,8 @@ client.on('error', e => error('Client error thrown:', e))
       (message.channel.type === 'text' && (
         // User can manage the guild, and can use bot commands anywhere
         message.channel.permissionsFor(message.member).missing(['MANAGE_GUILD']).length === 0 ||
-        // Command was run in `#dev-bot`
-        message.channel.name === 'dev-bot' ||
+        // Command was run in `#****-bot`
+        message.channel.name.endsWith('-bot') ||
         // Command is allowed in this channel
         (!command.channels || command.channels.includes(message.channel.name))
       ))

--- a/index.js
+++ b/index.js
@@ -71,19 +71,19 @@ client.on('error', e => error('Client error thrown:', e))
     }
 
     // Check the user has the required permissions
-    if (message.channel.type === 'text' && message.channel.memberPermissions(message.member).missing(command.userperms).length) {
+    if (message.channel.type === 'text' && message.channel.permissionsFor(message.member).missing(command.userperms).length) {
       return message.reply('You do not have the required permissions to run this command.');
     }
 
     // Check the bot has the required permissions
-    if (message.channel.type === 'text' && message.channel.memberPermissions(message.guild.me).missing(command.botperms).length) {
+    if (message.channel.type === 'text' && message.channel.permissionsFor(message.guild.me).missing(command.botperms).length) {
       return message.reply('I do not have the required permissions to run this command.');
     }
 
     const commandAllowedHere = (
       (message.channel.type === 'text' && (
         // User can manage the guild, and can use bot commands anywhere
-        message.channel.memberPermissions(message.member).missing(['MANAGE_GUILD']).length === 0 ||
+        message.channel.permissionsFor(message.member).missing(['MANAGE_GUILD']).length === 0 ||
         // Command was run in `#dev-bot`
         message.channel.name === 'dev-bot' ||
         // Command is allowed in this channel

--- a/index.js
+++ b/index.js
@@ -96,14 +96,12 @@ client.on('error', e => error('Client error thrown:', e))
     );
 
     if (!commandAllowedHere) {
-      let botChannelMessage = '';
+      let botReply = [`This is not the correct channel for \`${prefix}${command.name}\`.`];
       if (command.channels && command.channels.length !== 0) {
-        botChannelMessage = `Please try again in ${formatChannelList(message.guild, command.channels)}.`
+        botReply.push(`Please try again in ${formatChannelList(message.guild, command.channels)}.`);
       }
-      const safeMessage = message.content.replace(/`/g, '');
-      return message
-        .reply(`This is not the correct channel for \`${safeMessage}\`. ${botChannelMessage}`)
-        .then(() => message.delete().catch((e) => error('Unable to delete message:', e)));
+      message.delete().catch((e) => error('Unable to delete message:', e));
+      return message.reply(botReply);
     }
 
     // Check the user has supplied enough arguments for the command


### PR DESCRIPTION
This restricts commands to certain channels, and displays a message if the command is not permitted in the current channel based on the channels that exist in this server. Users with the `MANAGE_GUILD` permission can run commands in any channel, and all commands can be run in `#dev_bot`. If a command has a channels list of `[]`, it can only be used by privileged users or in `#dev_bot`.

![image](https://user-images.githubusercontent.com/90011/96626490-c9035800-12cc-11eb-98ac-8984b98f45a1.png)

The `!help` command has been updated to preemptively inform users of the appropriate channel to run each command in. There is a limit of 25 embeds, and I have 21 embeds on the main discord, and was exceeding the limit on my development discord. Adding the channel would add an additional 3-4 embed (depending on permissions), and with the expectation of additional commands in the future, I flattened out the embeds. It isn't as pretty, but the only alternative option is to split the reply into multiple messages when we will exceed the embed limit.

Help for users with the ability to manage the guild
![image](https://user-images.githubusercontent.com/90011/96626135-51352d80-12cc-11eb-81c2-f7a531232cd5.png)

Help for regular users
![image](https://user-images.githubusercontent.com/90011/96625547-8f7e1d00-12cb-11eb-9230-448c5ec41448.png)

Help on the Pokeclicker Development discord (fewer channels)
![image](https://user-images.githubusercontent.com/90011/96625682-bccacb00-12cb-11eb-80d5-ecc82d9928f7.png)
