### PR TITLE
Whitelist Discord Status website (Detected as "free nitro" phishing link)

### DIFF
--- a/regexMatches.js
+++ b/regexMatches.js
@@ -145,7 +145,7 @@ module.exports = [
   {
     regex: /(https?:\/\/)?(www\.)?(([a-c]|[e-z])iscord|d[a-z]iscord|d([a-h]|[j-z])scord|di[a-z]scord|di([a-r]|[t-z])cord|dis[a-z]cord|dis([a-b]|[d-z])ord|disc[a-z]ord|disc([a-n]|[p-z])rd|disco[a-z]rd|disco([a-q]|[s-z])d|discor[a-z]d|discor([a-c]|[e-z])|discord[a-z])[\w-]+\.\w{1,10}\//i,
     execute: async (message, client) => {
-      if (/(https?:\/\/)?(www\.)?(discord\.\w{1,3}|discordapp\.\w{1,3})\//i.test(message.content)) {
+      if (/(https?:\/\/)?(www\.)?(discord\.\w{1,3}|discordapp\.\w{1,3}|discordstatus\.\w{1,3})\//i.test(message.content)) {
         return;
       }
       let time = 2 * HOUR;


### PR DESCRIPTION
Affected website: https://discordstatus.com/
I don't think there are any other TLDs for that website, but I copied the `\.\w{1,3}` approach from the other domains anyway.