### PR TITLE
Update /pokemon dungeon list

### DIFF
--- a/slash_commands/pokemon.js
+++ b/slash_commands/pokemon.js
@@ -167,7 +167,7 @@ module.exports = {
       }
       // Dungeon
       if (pokemon.locations[PokemonLocationType.Dungeon]) {
-        const description = pokemon.locations[PokemonLocationType.Dungeon].join('\n');
+        const description = pokemon.locations[PokemonLocationType.Dungeon].map(d => `${d.dungeon}${d.requirements ? `🔒\n***Unlock Requirements:***\n_${d.requirements.replace(/\band\b/g, '\nand').replace(/\bor\b/g, '\nor')}_` : ''}`).join('\n');
         embed.addFields({
           name: '❯ Dungeons',
           value:  description,


### PR DESCRIPTION
The v0.10.16 game update added requirements to the data returned by the dungeon pokemon location function, this updates the bot to correctly display the dungeon list & requirements.

What it currently displays:
![image](https://github.com/RedSparr0w/Discord-bot-pokeclicker/assets/672420/b5cd45fa-0b3e-4570-9f78-4e57aa132af2)
