### PR TITLE
Allow 'bird' or 'birb' as answer for normal/flying type

### DIFF
--- a/other/quiz/quiz_questions.js
+++ b/other/quiz/quiz_questions.js
@@ -197,7 +197,11 @@ const pokemonType = () => new Promise(resolve => {
   (async () => {
     const pokemon = getRandomPokemon();
     const types = pokemon.type.map(t => PokemonType[t]);
-    const answer = new RegExp(`^\\W*(${types.join('\\W*')}|${types.reverse().join('\\W*')})\\b`, 'i');
+    let memeAnswer = null;
+    if (types.includes('Flying') && types.includes('Normal')) {
+      memeAnswer = 'bir[bd]';
+    }
+    const answer = new RegExp(`^\\W*(${types.join('\\W*')}|${types.reverse().join('\\W*')}${memeAnswer && `|${memeAnswer}`})\\b`, 'i');
 
     let amount = getAmount();
 

--- a/other/quiz/quiz_questions.js
+++ b/other/quiz/quiz_questions.js
@@ -197,7 +197,7 @@ const pokemonType = () => new Promise(resolve => {
   (async () => {
     const pokemon = getRandomPokemon();
     const types = pokemon.type.map(t => PokemonType[t]);
-    let memeAnswer = null;
+    let memeAnswer = '';
     if (types.includes('Flying') && types.includes('Normal')) {
       memeAnswer = 'bir[bd]';
     }


### PR DESCRIPTION
(is this the right branch?)

can't do `(${forward}|${reverse}|${meme})` when blank meme because it matches on the empty strings in between characters 😞 