### PR TITLE
Remove channel restrictions on /companion command

### DIFF
--- a/slash_commands/companion.js
+++ b/slash_commands/companion.js
@@ -9,7 +9,6 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SendMessages', 'EmbedLinks'],
   userperms   : [],
-  channels    : ['bot-coins', 'game-corner', 'bot-commands'],
   execute     : async (interaction) => {
     const embed = new EmbedBuilder()
       .setDescription('Check out the [PokéClicker Companion](https://companion.pokeclicker.com/) website for some useful tools!')


### PR DESCRIPTION
/companion could only be used in #bot-coins #game-corner and #bot-commands. This way people can easily link to it in other channels when the companion is asked about

Not sure if you need to do whatever it is that updates commands on the server after merging this