### PR TITLE
Fix Toxtricity needing to be spelt Toxtricitycity in quiz

### DIFF
--- a/other/quiz/quiz.js
+++ b/other/quiz/quiz.js
@@ -59,7 +59,7 @@ const newQuiz = async (guild, reoccur = false) => {
   if (reoccur) setTimeout(() => newQuiz(guild, reoccur), time_limit + ANSWER_TIME_LIMIT);
 
   // Which messages are we trying to catch
-  const filter = m => quiz.answer.test(m.content.replace(/\s*(town|city|island)/i, ''));
+  const filter = m => quiz.answer.test(m.content);
 
   // Our finished timestamp
   let finished = 0;

--- a/other/quiz/quiz_questions.js
+++ b/other/quiz/quiz_questions.js
@@ -37,7 +37,7 @@ const defaultEndFunction = (title, image, description) => async (m, e) => {
   m.channel.send({ embeds: [embed] }).catch((...args) => warn('Unable to post quiz answer', ...args));
 };
 const getPokemonByName = name => pokemonList.find(p => p.name == name);
-const pokemonNameNormalized = (name) => name.replace(/\s?\(.+\)$/, '').replace(/.*(Magikarp).*/, '$1').replace(/\W/g, '.?').replace(/.*((Segin|Schedar|Segin|Ruchbah|Caph)\.\?Starmobile).*/, '($1)|(Revavroom)').replace(/(Valencian|Pinkan|Pink|Handout|Charity|Blessing|Crystal|Titan)\s*/gi, '($1)?').replace(/Noble\s*/g, '(Noble|Hisuian)?\\s*');
+const pokemonNameNormalized = (name) => name.replace(/\s?\(.+\)$/, '').replace(/.*(Magikarp).*/, '$1').replace(/\W/g, '.?').replace(/.*((Segin|Schedar|Segin|Ruchbah|Caph)\.\?Starmobile).*/, '($1)|(Revavroom)').replace(/(Valencian|Pinkan|Pink|Handout|Charity|Blessing|Crystal|Titan)\s*/gi, '($1)?').replace(/Noble\s*/g, '(Noble|Hisuian)?\\s*').replace('Toxtricity', 'Toxtri(city|town|island)?city');
 const evolutionsNormalized = (evolution) => evolution.replace(/\W|_/g, '.?').replace(/(Level)\s*/gi, '($1)?');
 const pokemonNameAnswer = (name) => new RegExp(`^\\W*${pokemonNameNormalized(name)}\\b`, 'i');
 const berryList = Object.keys(berryType).filter(b => isNaN(b) && b != 'None');


### PR DESCRIPTION
The candidate responses to town-related questions were edited to take off « city », « town » or « island » from them before getting compared to the correct answer. Turns out it was not needed [anymore ?], lol.

Anyway, removed that trimming and it still works well with Toxtricity or any town-related questions. Kept Toxtricitycity and the like as valid, though.