### PR TITLE
Changed the order of the "beginners hint" to be more in line with usefulness

### DIFF
--- a/regexMatches.js
+++ b/regexMatches.js
@@ -136,7 +136,7 @@ module.exports = [
     
       // #bot-commands
       const botCommands = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'bot-commands') || '#bot-commands' : '#bot-commands';
-      if (botCommands) description.push(`Check out There may be a command available in ${botCommands}.`);
+      if (botCommands) description.push(`There may be a command available in ${botCommands} to help you. Do /help in that Channel for a list of available commands.`);
 
       // Create the embed
       const embed = new EmbedBuilder().setDescription(description.join('\n')).setColor('Random');

--- a/regexMatches.js
+++ b/regexMatches.js
@@ -127,15 +127,15 @@ module.exports = [
       const faq = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'faq') || '#faq' : '#faq';
       if (faq) description.push(`You might be able to find the answer you are looking for in the ${faq}.`);
 
-      // #bot-commands
-      const botCommands = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'bot-commands') || '#bot-commands' : '#bot-commands';
-      if (botCommands) description.push(`There may be a command available in ${botCommands}.`);
-
+      // wiki
+      description.push('The [PokéClicker Wiki](https://wiki.pokeclicker.com/) also contains a lot of valuable information.');
+      S
       // companion
       description.push('The [PokéClicker Companion](https://companion.pokeclicker.com/) has some useful tools.');
     
-      // wiki
-      description.push('The [PokéClicker Wiki](https://wiki.pokeclicker.com/) also contains a lot of valuable information.');
+      // #bot-commands
+      const botCommands = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'bot-commands') || '#bot-commands' : '#bot-commands';
+      if (botCommands) description.push(`There may be a command available in ${botCommands}.`);
 
       // Create the embed
       const embed = new EmbedBuilder().setDescription(description.join('\n')).setColor('Random');

--- a/regexMatches.js
+++ b/regexMatches.js
@@ -125,17 +125,18 @@ module.exports = [
 
       // #faq
       const faq = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'faq') || '#faq' : '#faq';
-      if (faq) description.push(`You might be able to find the answer you are looking for in the ${faq}.`);
+      const botFaq = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'bot-faq') || '#bot-faq' : '#bot-faq';
+      if (faq) description.push(`You might be able to find the answer you are looking for in the ${faq} or ${botFaq}.`);
 
       // wiki
       description.push('The [PokéClicker Wiki](https://wiki.pokeclicker.com/) also contains a lot of valuable information.');
-      S
+      
       // companion
       description.push('The [PokéClicker Companion](https://companion.pokeclicker.com/) has some useful tools.');
     
       // #bot-commands
       const botCommands = message.guild ? message.guild.channels.cache.find(channel => channel.name == 'bot-commands') || '#bot-commands' : '#bot-commands';
-      if (botCommands) description.push(`There may be a command available in ${botCommands}.`);
+      if (botCommands) description.push(`Check out There may be a command available in ${botCommands}.`);
 
       // Create the embed
       const embed = new EmbedBuilder().setDescription(description.join('\n')).setColor('Random');

--- a/slash_commands/help.js
+++ b/slash_commands/help.js
@@ -27,6 +27,7 @@ module.exports = {
   cooldown    : 3,
   botperms    : ['SendMessages', 'EmbedLinks'],
   userperms   : [],
+  channels    : ['bot-commands', 'game-corner'],
   execute     : async (interaction) => {
     let command = interaction.options.get('command')?.value;
     let commands = interaction.client.slashCommands;


### PR DESCRIPTION
The beginners hint grew historically which may not be the most optimal way to convey information to new players.

before:
faq > bot commands > companion > wiki 
after:
faq > wiki > companion > bot commands